### PR TITLE
Support for automatic removal of older messages

### DIFF
--- a/src/App/Controls/Sessions/SessionOptionsPanel.xaml
+++ b/src/App/Controls/Sessions/SessionOptionsPanel.xaml
@@ -88,11 +88,20 @@
         <labs:SettingsCard
             Description="{ext:Locale Name=StreamOutputDescription}"
             Header="{ext:Locale Name=StreamOutput}"
-            Visibility="{x:Bind StreamOutputVisibility, Mode=OneWay}">
+            Visibility="{x:Bind IsSemanticOptions, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
             <labs:SettingsCard.HeaderIcon>
                 <controls:FluentIcon Symbol="Diagram" />
             </labs:SettingsCard.HeaderIcon>
             <ToggleSwitch IsOn="{x:Bind ViewModel.UseStreamOutput, Mode=TwoWay}" />
+        </labs:SettingsCard>
+        <labs:SettingsCard
+            Description="{ext:Locale Name=AutoRemoveEarlierMessageDescription}"
+            Header="{ext:Locale Name=AutoRemoveEarlierMessage}"
+            Visibility="{x:Bind IsSemanticOptions, Mode=OneWay, Converter={StaticResource BoolToVisibilityReverseConverter}}">
+            <labs:SettingsCard.HeaderIcon>
+                <controls:FluentIcon Symbol="TrayItemRemove" />
+            </labs:SettingsCard.HeaderIcon>
+            <ToggleSwitch IsOn="{x:Bind ViewModel.AutoRemoveEarlierMessage, Mode=TwoWay}" />
         </labs:SettingsCard>
     </StackPanel>
 </local:SessionOptionsPanelBase>

--- a/src/App/Controls/Sessions/SessionOptionsPanel.xaml.cs
+++ b/src/App/Controls/Sessions/SessionOptionsPanel.xaml.cs
@@ -11,10 +11,10 @@ namespace FantasyCopilot.App.Controls.Sessions;
 public sealed partial class SessionOptionsPanel : SessionOptionsPanelBase
 {
     /// <summary>
-    /// Dependency property for <see cref="StreamOutputVisibility"/>.
+    /// Dependency property for <see cref="IsSemanticOptions"/>.
     /// </summary>
-    public static readonly DependencyProperty StreamOutputVisibilityProperty =
-        DependencyProperty.Register(nameof(StreamOutputVisibility), typeof(Visibility), typeof(SessionOptionsPanel), new PropertyMetadata(Visibility.Visible));
+    public static readonly DependencyProperty IsSemanticOptionsProperty =
+        DependencyProperty.Register(nameof(IsSemanticOptions), typeof(bool), typeof(SessionOptionsPanel), new PropertyMetadata(false));
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SessionOptionsPanel"/> class.
@@ -40,10 +40,10 @@ public sealed partial class SessionOptionsPanel : SessionOptionsPanelBase
     /// <summary>
     /// Gets or sets the visibility of the stream output toggle.
     /// </summary>
-    public Visibility StreamOutputVisibility
+    public bool IsSemanticOptions
     {
-        get => (Visibility)GetValue(StreamOutputVisibilityProperty);
-        set => SetValue(StreamOutputVisibilityProperty, value);
+        get => (bool)GetValue(IsSemanticOptionsProperty);
+        set => SetValue(IsSemanticOptionsProperty, value);
     }
 
     private void OnTokenNumberValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)

--- a/src/App/Controls/Sessions/SessionPanel.xaml
+++ b/src/App/Controls/Sessions/SessionPanel.xaml
@@ -179,12 +179,18 @@
                             Spacing="8"
                             Visibility="{x:Bind ViewModel.ErrorText, Mode=OneWay, Converter={StaticResource ObjectToVisibilityConverter}}">
                             <TextBlock
-                                MaxWidth="200"
+                                x:Name="ErrorBlock"
+                                MaxWidth="240"
                                 HorizontalAlignment="Center"
+                                MaxLines="3"
                                 Style="{StaticResource CaptionTextBlockStyle}"
                                 Text="{x:Bind ViewModel.ErrorText, Mode=OneWay}"
                                 TextAlignment="Center"
-                                TextWrapping="Wrap" />
+                                TextWrapping="Wrap">
+                                <ToolTipService.ToolTip>
+                                    <ToolTip Content="{x:Bind ViewModel.ErrorText, Mode=OneWay}" IsEnabled="{x:Bind ErrorBlock.IsTextTrimmed, Mode=OneWay}" />
+                                </ToolTipService.ToolTip>
+                            </TextBlock>
                             <HyperlinkButton
                                 Padding="4"
                                 HorizontalAlignment="Center"

--- a/src/App/Controls/Workspace/SemanticSkillEditor.xaml
+++ b/src/App/Controls/Workspace/SemanticSkillEditor.xaml
@@ -78,7 +78,7 @@
 
                 <sessions:SessionOptionsPanel
                     x:Name="OptionsPanel"
-                    StreamOutputVisibility="Collapsed"
+                    IsSemanticOptions="Collapsed"
                     ViewModel="{x:Bind ViewModel.Options, Mode=OneWay}" />
             </StackPanel>
         </ScrollViewer>

--- a/src/App/Resources/Strings/en-US/Resources.resw
+++ b/src/App/Resources/Strings/en-US/Resources.resw
@@ -213,6 +213,12 @@
   <data name="AutoDetect" xml:space="preserve">
     <value>Automatically detect</value>
   </data>
+  <data name="AutoRemoveEarlierMessage" xml:space="preserve">
+    <value>Auto Remove Earlier Message</value>
+  </data>
+  <data name="AutoRemoveEarlierMessageDescription" xml:space="preserve">
+    <value>When the token limit is reached, earlier messages are removed to continue the conversation</value>
+  </data>
   <data name="AwesomePrompt" xml:space="preserve">
     <value>Awesome ChatGPT Prompts</value>
   </data>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -1464,4 +1464,10 @@
   <data name="StreamOutputDescription" xml:space="preserve">
     <value>逐句逐段获取语言模型的响应</value>
   </data>
+  <data name="AutoRemoveEarlierMessage" xml:space="preserve">
+    <value>自动移除早期消息</value>
+  </data>
+  <data name="AutoRemoveEarlierMessageDescription" xml:space="preserve">
+    <value>达到令牌上限时，将移除较早的消息以继续对话</value>
+  </data>
 </root>

--- a/src/Libs/Libs.NativeSkills/StaticHelpers.cs
+++ b/src/Libs/Libs.NativeSkills/StaticHelpers.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Fantasy Copilot. All rights reserved.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using FantasyCopilot.Models.App;
+using Microsoft.SemanticKernel.AI.ChatCompletion;
 
 namespace FantasyCopilot.Libs.NativeSkills;
 
@@ -13,5 +17,56 @@ internal static class StaticHelpers
         return string.IsNullOrEmpty(data)
             ? default
             : JsonSerializer.Deserialize<T>(data);
+    }
+
+    internal static bool TryGetTokenLimit(this string errorMessage, out int maxTokens, out int messageTokens)
+    {
+        var pattern = @"maximum context length.*?(\d+).*?(\d+)";
+        var match = Regex.Match(errorMessage, pattern);
+        maxTokens = 0;
+        messageTokens = 0;
+        if (match.Success)
+        {
+            maxTokens = int.Parse(match.Groups[1].Value);
+            messageTokens = int.Parse(match.Groups[2].Value);
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static bool TryRemoveEarlierMessage(List<ChatHistory.Message> messages, int maxTokens, int messageTokens)
+    {
+        // If there are too few rounds, then message generation cannot continue by deleting messages.
+        if (messages.Count <= 1 || !messages.Any(p => p.AuthorRole == ChatHistory.AuthorRoles.Assistant))
+        {
+            return false;
+        }
+
+        var startIndex = messages.FirstOrDefault()?.AuthorRole == ChatHistory.AuthorRoles.System ? 1 : 0;
+        var difference = messageTokens - maxTokens;
+        var endIndex = -1;
+        var tempTokenRecord = 0;
+        for (var i = startIndex; i < messages.Count; i++)
+        {
+            var message = messages[i];
+
+            // Currently, there is no token algorithm that is suitable for most languages,
+            // so this is only an estimate and there is some error.
+            tempTokenRecord += message.Content.Length * 2;
+            if (tempTokenRecord >= difference)
+            {
+                endIndex = i;
+                break;
+            }
+        }
+
+        if (endIndex == -1)
+        {
+            return false;
+        }
+
+        messages.RemoveRange(startIndex, endIndex - startIndex + 1);
+        return true;
     }
 }

--- a/src/Models/Models.App/GPT/SessionOptions.cs
+++ b/src/Models/Models.App/GPT/SessionOptions.cs
@@ -40,6 +40,11 @@ public class SessionOptions
     public bool UseStreamOutput { get; set; }
 
     /// <summary>
+    /// Automatically remove earlier messages when the token limit is reached.
+    /// </summary>
+    public bool AutoRemoveEarlierMessage { get; set; }
+
+    /// <summary>
     /// Create a copy based on its own properties.
     /// </summary>
     /// <returns>New <see cref="SessionOptions"/> object.</returns>
@@ -52,5 +57,6 @@ public class SessionOptions
             FrequencyPenalty = FrequencyPenalty,
             PresencePenalty = PresencePenalty,
             UseStreamOutput = UseStreamOutput,
+            AutoRemoveEarlierMessage = AutoRemoveEarlierMessage,
         };
 }

--- a/src/Models/Models.Constants/AppConstants.cs
+++ b/src/Models/Models.Constants/AppConstants.cs
@@ -39,4 +39,6 @@ public static class AppConstants
 
     public const string DefaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.50";
     public const string KnowledgeBaseCollectionId = "KnowledgeBase";
+
+    public const string TokenLimitMessage = @"maximum context length.*?(\d+).*?(\d+)";
 }

--- a/src/Models/Models.Constants/StringNames.cs
+++ b/src/Models/Models.Constants/StringNames.cs
@@ -467,4 +467,6 @@ public enum StringNames
     AppKeyPlaceholderText,
     StreamOutput,
     StreamOutputDescription,
+    AutoRemoveEarlierMessage,
+    AutoRemoveEarlierMessageDescription,
 }

--- a/src/ViewModels/ViewModels.Desktop/SessionOptionsViewModel/SessionOptionsViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Desktop/SessionOptionsViewModel/SessionOptionsViewModel.Properties.cs
@@ -29,4 +29,7 @@ public sealed partial class SessionOptionsViewModel
 
     [ObservableProperty]
     private bool _useStreamOutput;
+
+    [ObservableProperty]
+    private bool _autoRemoveEarlierMessage;
 }

--- a/src/ViewModels/ViewModels.Desktop/SessionOptionsViewModel/SessionOptionsViewModel.cs
+++ b/src/ViewModels/ViewModels.Desktop/SessionOptionsViewModel/SessionOptionsViewModel.cs
@@ -29,6 +29,7 @@ public sealed partial class SessionOptionsViewModel : ViewModelBase, ISessionOpt
             FrequencyPenalty = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultFrequencyPenalty, 0d);
             PresencePenalty = _settingsToolkit.ReadLocalSetting(SettingNames.DefaultPresencePenalty, 0d);
             UseStreamOutput = true;
+            AutoRemoveEarlierMessage = false;
         }
         else
         {
@@ -38,6 +39,7 @@ public sealed partial class SessionOptionsViewModel : ViewModelBase, ISessionOpt
             FrequencyPenalty = options.FrequencyPenalty;
             PresencePenalty = options.PresencePenalty;
             UseStreamOutput = options.UseStreamOutput;
+            AutoRemoveEarlierMessage = options.AutoRemoveEarlierMessage;
         }
     }
 
@@ -51,5 +53,6 @@ public sealed partial class SessionOptionsViewModel : ViewModelBase, ISessionOpt
             FrequencyPenalty = FrequencyPenalty,
             PresencePenalty = PresencePenalty,
             UseStreamOutput = UseStreamOutput,
+            AutoRemoveEarlierMessage = AutoRemoveEarlierMessage,
         };
 }

--- a/src/ViewModels/ViewModels.Interfaces/ISessionOptionsViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/ISessionOptionsViewModel.cs
@@ -43,6 +43,11 @@ public interface ISessionOptionsViewModel : INotifyPropertyChanged
     bool UseStreamOutput { get; set; }
 
     /// <summary>
+    /// Automatically remove earlier messages when the token limit is reached.
+    /// </summary>
+    bool AutoRemoveEarlierMessage { get; set; }
+
+    /// <summary>
     /// Initialize the view model.
     /// </summary>
     /// <param name="options">Existing configuration.</param>


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close #10 

Introduce a new configuration option that enables the removal of older messages to free up token capacity for subsequent messages when the token limit is reached.

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

<!-- - Bug fix -->
- Feature
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

An error will occur when the token limit is reached within the context.

## What is the new behavior?

If the option is turned on, older messages will be removed when the context reaches the token limit

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates
