### PR TITLE
Show error dialog when import failed

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -75,6 +75,7 @@
     <None Remove="Controls\Steps\VariableRedirectStepItem.xaml" />
     <None Remove="Controls\StorageSearchItem.xaml" />
     <None Remove="Controls\TextToSpeechPanel.xaml" />
+    <None Remove="Controls\TipDialog.xaml" />
     <None Remove="Controls\TipPopup.xaml" />
     <None Remove="Controls\WorkflowEditor.xaml" />
     <None Remove="Controls\WorkflowInputItem.xaml" />
@@ -452,6 +453,9 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="Controls\Settings\CloseBehaviorSettingSection.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Controls\TipDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <None Update="NLog.config">

--- a/src/App/Controls/TipDialog.xaml
+++ b/src/App/Controls/TipDialog.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentDialog
+    x:Class="FantasyCopilot.App.Controls.TipDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:ext="using:FantasyCopilot.App.Resources.Extension"
+    xmlns:local="using:FantasyCopilot.App.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="{ext:Locale Name=Tip}"
+    CloseButtonText="{ext:Locale Name=Confirm}"
+    DefaultButton="Close"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock
+            x:Name="TipBlock"
+            MaxWidth="320"
+            TextWrapping="Wrap" />
+    </Grid>
+</ContentDialog>

--- a/src/App/Controls/TipDialog.xaml.cs
+++ b/src/App/Controls/TipDialog.xaml.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Fantasy Copilot. All rights reserved.
+
+namespace FantasyCopilot.App.Controls;
+
+/// <summary>
+/// Tip dialog.
+/// </summary>
+public sealed partial class TipDialog : ContentDialog
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TipDialog"/> class.
+    /// </summary>
+    public TipDialog(string text)
+    {
+        InitializeComponent();
+        TipBlock.Text = text;
+    }
+}

--- a/src/App/MainWindow.xaml.cs
+++ b/src/App/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class MainWindow : Window
         _appViewModel.PropertyChanged += OnAppViewModelPropertyChanged;
         _appViewModel.NavigateRequest += OnAppViewModelNavigateRequest;
         _appViewModel.RequestShowTip += OnAppViewModelRequestShowTip;
+        _appViewModel.RequestShowMessage += OnAppViewModelRequestShowMessageAsync;
         Instance = this;
     }
 
@@ -120,6 +121,15 @@ public sealed partial class MainWindow : Window
 
     private void OnAppViewModelRequestShowTip(object sender, AppTipNotificationEventArgs e)
         => new TipPopup(e.Message).ShowAsync(e.Type);
+
+    private async void OnAppViewModelRequestShowMessageAsync(object sender, string e)
+    {
+        var dialog = new TipDialog(e)
+        {
+            XamlRoot = Content.XamlRoot,
+        };
+        await dialog.ShowAsync();
+    }
 
     private void OnSettingsButtonClick(object sender, RoutedEventArgs e)
         => _appViewModel.Navigate(PageType.Settings);

--- a/src/App/Resources/Strings/en-US/Resources.resw
+++ b/src/App/Resources/Strings/en-US/Resources.resw
@@ -1413,6 +1413,9 @@
   <data name="TimePeriod" xml:space="preserve">
     <value>Time period</value>
   </data>
+  <data name="Tip" xml:space="preserve">
+    <value>Tip</value>
+  </data>
   <data name="Title" xml:space="preserve">
     <value>Title</value>
   </data>

--- a/src/App/Resources/Strings/zh-CN/Resources.resw
+++ b/src/App/Resources/Strings/zh-CN/Resources.resw
@@ -1542,4 +1542,7 @@
   <data name="HideWhenCloseDescription" xml:space="preserve">
     <value>关闭窗口时隐藏应用而非退出</value>
   </data>
+  <data name="Tip" xml:space="preserve">
+    <value>提示</value>
+  </data>
 </root>

--- a/src/Models/Models.Constants/StringNames.cs
+++ b/src/Models/Models.Constants/StringNames.cs
@@ -493,4 +493,5 @@ public enum StringNames
     Feature,
     HideWhenClose,
     HideWhenCloseDescription,
+    Tip,
 }

--- a/src/ViewModels/ViewModels.Desktop/AppViewModel/AppViewModel.Properties.cs
+++ b/src/ViewModels/ViewModels.Desktop/AppViewModel/AppViewModel.Properties.cs
@@ -56,6 +56,9 @@ public sealed partial class AppViewModel
     public event EventHandler<AppTipNotificationEventArgs> RequestShowTip;
 
     /// <inheritdoc/>
+    public event EventHandler<string> RequestShowMessage;
+
+    /// <inheritdoc/>
     public ObservableCollection<NavigateItem> NavigateItems { get; }
 
     /// <inheritdoc/>

--- a/src/ViewModels/ViewModels.Desktop/AppViewModel/AppViewModel.cs
+++ b/src/ViewModels/ViewModels.Desktop/AppViewModel/AppViewModel.cs
@@ -87,6 +87,10 @@ public sealed partial class AppViewModel : ViewModelBase, IAppViewModel
     public void ShowTip(string message, InfoType type = InfoType.Information)
         => RequestShowTip?.Invoke(this, new AppTipNotificationEventArgs(message, type));
 
+    /// <inheritdoc/>
+    public void ShowMessage(string message)
+        => RequestShowMessage?.Invoke(this, message);
+
     [RelayCommand]
     private static void RestartAsAdmin()
     {

--- a/src/ViewModels/ViewModels.Desktop/KnowledgePageViewModel/KnowledgePageViewModel.cs
+++ b/src/ViewModels/ViewModels.Desktop/KnowledgePageViewModel/KnowledgePageViewModel.cs
@@ -135,8 +135,14 @@ public sealed partial class KnowledgePageViewModel : ViewModelBase, IKnowledgePa
 
             if (!string.IsNullOrEmpty(tip))
             {
-                var infoType = isWarning ? InfoType.Warning : InfoType.Success;
-                _appViewModel.ShowTip(tip, infoType);
+                if (isWarning)
+                {
+                    _appViewModel.ShowMessage(tip);
+                }
+                else
+                {
+                    _appViewModel.ShowTip(tip, InfoType.Success);
+                }
             }
 
             var baseData = new KnowledgeBase

--- a/src/ViewModels/ViewModels.Interfaces/IAppViewModel.cs
+++ b/src/ViewModels/ViewModels.Interfaces/IAppViewModel.cs
@@ -29,6 +29,11 @@ public interface IAppViewModel : INotifyPropertyChanged
     event EventHandler<AppTipNotificationEventArgs> RequestShowTip;
 
     /// <summary>
+    /// Fired when request show message.
+    /// </summary>
+    event EventHandler<string> RequestShowMessage;
+
+    /// <summary>
     /// Main window object.
     /// </summary>
     object MainWindow { get; set; }
@@ -131,4 +136,10 @@ public interface IAppViewModel : INotifyPropertyChanged
     /// <param name="message">Message content.</param>
     /// <param name="type">Message type.</param>
     void ShowTip(string message, InfoType type = InfoType.Information);
+
+    /// <summary>
+    /// Display a dialog box to remind the user of something.
+    /// </summary>
+    /// <param name="message">Message.</param>
+    void ShowMessage(string message);
 }


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close #38 

1. If the import of the knowledge base file fails, notify the user through a dialog box.
2. Release the database occupancy promptly after importing a file or folder.

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

<!-- - Bug fix -->
- Feature
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

After a failed import, although there is a prompt, it is easy to overlook.

## What is the new behavior?

Provide more explicit prompts.

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates

<!-- If this PR contains a breaking update, please describe below the impact on existing applications and how to adapt to the new changes -->
