### PR TITLE
Fix baidu translate issue

### DIFF
--- a/src/Services/Services.Desktop/BaiduTranslateService/BaiduTranslateService.Methods.cs
+++ b/src/Services/Services.Desktop/BaiduTranslateService/BaiduTranslateService.Methods.cs
@@ -14,6 +14,7 @@ namespace FantasyCopilot.Services;
 public sealed partial class BaiduTranslateService
 {
     private const string TranslateApi = "http://api.fanyi.baidu.com/api/trans/vip/translate";
+    private const int MaxTextLength = 1100;
     private readonly ISettingsToolkit _settingsToolkit;
     private readonly HttpClient _httpClient;
     private string _salt;

--- a/src/Services/Services.Desktop/BaiduTranslateService/BaiduTranslateService.cs
+++ b/src/Services/Services.Desktop/BaiduTranslateService/BaiduTranslateService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,6 +55,46 @@ public sealed partial class BaiduTranslateService : ITranslateService
             sourceLanguage = "auto";
         }
 
+        text = text.Replace("\r", "\n").Replace("\n\n", "\n");
+        var textBuilder = new StringBuilder();
+        var resultBuilder = new StringBuilder();
+        foreach (var item in text.Split('\n'))
+        {
+            if (textBuilder.Length + item.Length > MaxTextLength)
+            {
+                // Due to the API request rate limit,
+                // a translation is requested at most once per second,
+                // so additional blocking is required here
+                if (resultBuilder.Length > 0)
+                {
+                    await Task.Delay(1000, cancellationToken);
+                }
+
+                var tempResult = await TranslateInternalAsync(textBuilder.ToString(), sourceLanguage, targetLanguage, cancellationToken);
+                resultBuilder.AppendLine(tempResult);
+                textBuilder.Clear();
+            }
+
+            textBuilder.AppendLine(item);
+        }
+
+        if (textBuilder.Length > 0)
+        {
+            if (resultBuilder.Length > 0)
+            {
+                await Task.Delay(1000, cancellationToken);
+            }
+
+            var tempResult = await TranslateInternalAsync(textBuilder.ToString(), sourceLanguage, targetLanguage, cancellationToken);
+            resultBuilder.AppendLine(tempResult);
+        }
+
+        return resultBuilder.ToString();
+    }
+
+    private async Task<string> TranslateInternalAsync(string text, string sourceLanguage, string targetLanguage, CancellationToken cancellationToken)
+    {
+        text = text.Replace("\r", "\n").Replace("\n\n", "\n");
         var dict = new Dictionary<string, string>
         {
             { "q", text },
@@ -77,14 +118,22 @@ public sealed partial class BaiduTranslateService : ITranslateService
         }
         else
         {
+            var sb = new StringBuilder();
             var hasResult = jele.TryGetProperty("trans_result", out var transResultEle);
             if (!hasResult)
             {
                 throw new Exception("No result.");
             }
 
-            transResultEle.EnumerateArray().FirstOrDefault().TryGetProperty("dst", out var dstEle);
-            return dstEle.ToString();
+            foreach (var item in transResultEle.EnumerateArray())
+            {
+                if (item.TryGetProperty("dst", out var dstEle))
+                {
+                    sb.AppendLine(dstEle.ToString());
+                }
+            }
+
+            return sb.ToString().Trim();
         }
     }
 }


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close #50 

Fix the issue where Baidu Translate only displays the first paragraph

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

- Bug fix
<!-- - Feature -->
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

Baidu Translate only displays the first paragraph of content

## What is the new behavior?

1. Segment the text and translate it in batches when the text volume is large
2. Fix previous code errors. Baidu Translate will generate multiple translation results based on paragraphs, and now they can be combined instead of just taking the first one

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates

<!-- If this PR contains a breaking update, please describe below the impact on existing applications and how to adapt to the new changes -->

## Remark

There are still many restrictions on Baidu translation
