### PR TITLE
修复插件导入未完成时的文件残留问题

### DIFF
--- a/src/Toolkits/Toolkits.Desktop/CacheToolkit/CacheToolkit.Plugin.cs
+++ b/src/Toolkits/Toolkits.Desktop/CacheToolkit/CacheToolkit.Plugin.cs
@@ -65,7 +65,25 @@ public sealed partial class CacheToolkit
 
         await Task.Run(() =>
         {
-            ZipFile.ExtractToDirectory(pluginZipPath, pluginFolder, true);
+            try
+            {
+                ZipFile.ExtractToDirectory(pluginZipPath, pluginFolder, true);
+            }
+            catch (System.Exception)
+            {
+                var tempFolderPath = ApplicationData.Current.TemporaryFolder.Path;
+                var tempDirectory = new DirectoryInfo(tempFolderPath);
+                var files = tempDirectory.GetFiles();
+                if (files.Length > 0)
+                {
+                    foreach (var file in files)
+                    {
+                        file.Delete();
+                    }
+                }
+
+                throw;
+            }
         });
 
         _plugins?.Add(config);


### PR DESCRIPTION
<!-- 🚨 Please do not skip or delete the following information, they are all information required for assessment and testing, complete filling will help you pass the review faster 🚨 -->

<!-- 👉 A PR is best to address only one issue, unless those issues are related to each other -->

<!-- 📝 Please always open the PR `☑️ Allow edits by maintainers` button，Clean reader uses a stricter project template, and the maintainer can help you fix some minor errors or formatting issues 🎉 -->

## Close

插件如果导入过程中出错，可能会在临时文件夹中残留文件，导致下次导入失败。

## PR type

What is the purpose of this PR?

<!-- Please uncomment the corresponding type -->

- Bug fix
<!-- - Feature -->
<!-- - Code style -->
<!-- - Build or CI update -->
<!-- - Document update -->
<!-- - Others： -->

## What is the current behavior?

插件如果导入过程中出错，可能会在临时文件夹中残留文件，导致下次导入失败。

## What is the new behavior?

导入失败后清除临时文件夹

## PR checklist

Please check that your PR meets the following requirements: <!-- remove those that don't apply to the current PR -->

- [x] App successfully launched
- [x] File headers have been added to all source files
- [x] **NOT** Contains breaking updates
